### PR TITLE
Cherry-pick workaround to fix msvc warning about <span> header

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -279,6 +279,11 @@ namespace ranges
 #define RANGES_WORKAROUND_MSVC_OLD_LAMBDA
 #endif
 
+#if _MSVC_LANG <= 201703L
+#define RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN // MSVC provides a <span> header that is
+                                             // guarded against use with std <= 17
+#endif
+
 #elif defined(__GNUC__) || defined(__clang__)
 #define RANGES_PRAGMA(X) _Pragma(#X)
 #define RANGES_DIAGNOSTIC_PUSH RANGES_PRAGMA(GCC diagnostic push)

--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -14,6 +14,8 @@
 #ifndef RANGES_V3_RANGE_ACCESS_HPP
 #define RANGES_V3_RANGE_ACCESS_HPP
 
+#include <range/v3/detail/config.hpp>
+
 #include <functional> // for reference_wrapper (whose use with begin/end is deprecated)
 #include <initializer_list>
 #include <iterator>
@@ -21,7 +23,7 @@
 #include <utility>
 
 #ifdef __has_include
-#if __has_include(<span>)
+#if __has_include(<span>) && !defined(RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN)
 #include <span>
 #endif
 #if __has_include(<string_view>)

--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -14,12 +14,14 @@
 #ifndef RANGES_V3_RANGE_CONCEPTS_HPP
 #define RANGES_V3_RANGE_CONCEPTS_HPP
 
+#include <range/v3/detail/config.hpp>
+
 #include <initializer_list>
 #include <type_traits>
 #include <utility>
 
 #ifdef __has_include
-#if __has_include(<span>)
+#if __has_include(<span>) && !defined(RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN)
 #include <span>
 #endif
 #if __has_include(<string_view>)


### PR DESCRIPTION
MSVC's <span> only works when compiling with C++20. Otherwise it can
be included but not used. Including it causes the compiler to print
a warning.